### PR TITLE
Add navigation options for password reset and account creation

### DIFF
--- a/my-documents/CreateAccountView.swift
+++ b/my-documents/CreateAccountView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct CreateAccountView: View {
+    var body: some View {
+        Text("create_account_title")
+            .navigationTitle("create_account_title")
+    }
+}
+
+#Preview {
+    CreateAccountView()
+}

--- a/my-documents/ForgotPasswordView.swift
+++ b/my-documents/ForgotPasswordView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ForgotPasswordView: View {
+    var body: some View {
+        Text("forgot_password_title")
+            .navigationTitle("forgot_password_title")
+    }
+}
+
+#Preview {
+    ForgotPasswordView()
+}

--- a/my-documents/LoginView.swift
+++ b/my-documents/LoginView.swift
@@ -14,13 +14,14 @@ struct LoginView: View {
     @State private var passwordError: String?
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text("login_title")
-                .font(.title)
-            TextField("email_placeholder", text: $email)
-                .autocapitalization(.none)
-                .keyboardType(.emailAddress)
-                .textFieldStyle(.roundedBorder)
+        NavigationStack {
+            VStack(spacing: 16) {
+                Text("login_title")
+                    .font(.title)
+                TextField("email_placeholder", text: $email)
+                    .autocapitalization(.none)
+                    .keyboardType(.emailAddress)
+                    .textFieldStyle(.roundedBorder)
             if let emailError = emailError {
                 Text(emailError)
                     .foregroundColor(.red)
@@ -33,12 +34,21 @@ struct LoginView: View {
                     .foregroundColor(.red)
                     .font(.caption)
             }
-            Button("login_button") {
-                validate()
+                Button("login_button") {
+                    validate()
+                }
+                .buttonStyle(.borderedProminent)
+                .frame(maxWidth: .infinity)
+
+                NavigationLink("forgot_password_link") {
+                    ForgotPasswordView()
+                }
+                NavigationLink("create_account_link") {
+                    CreateAccountView()
+                }
             }
-            .buttonStyle(.borderedProminent)
+            .padding()
         }
-        .padding()
     }
 
     private func validate() {

--- a/my-documents/en.lproj/Localizable.strings
+++ b/my-documents/en.lproj/Localizable.strings
@@ -4,3 +4,7 @@
 "login_button" = "Sign In";
 "invalid_email" = "Invalid email address.";
 "invalid_password" = "Password must be at least 6 characters.";
+"forgot_password_link" = "Forgot Password";
+"create_account_link" = "Create Account";
+"forgot_password_title" = "Forgot Password";
+"create_account_title" = "Create Account";

--- a/my-documents/es.lproj/Localizable.strings
+++ b/my-documents/es.lproj/Localizable.strings
@@ -4,3 +4,7 @@
 "login_button" = "Ingresar";
 "invalid_email" = "Correo electrónico no válido.";
 "invalid_password" = "La contraseña debe tener al menos 6 caracteres.";
+"forgot_password_link" = "Olvidaste tu contraseña";
+"create_account_link" = "Crear cuenta";
+"forgot_password_title" = "Olvidaste tu contraseña";
+"create_account_title" = "Crear cuenta";


### PR DESCRIPTION
## Summary
- add Forgot Password and Create Account screens
- link to new screens from login and make login button full width
- localize new texts in English and Spanish

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689614374e2c832c934ee453d697b7ee