### PR TITLE
Implement create account screen with validation

### DIFF
--- a/my-documents/CreateAccountView.swift
+++ b/my-documents/CreateAccountView.swift
@@ -1,9 +1,127 @@
 import SwiftUI
 
 struct CreateAccountView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var fullName: String = ""
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var confirmPassword: String = ""
+    @State private var acceptTerms: Bool = false
+    @State private var dataConsent: Bool = false
+
+    @State private var fullNameError: String?
+    @State private var emailError: String?
+    @State private var passwordError: String?
+    @State private var confirmPasswordError: String?
+    @State private var termsError: String?
+    @State private var dataConsentError: String?
+
+    @State private var showAlert: Bool = false
+
     var body: some View {
-        Text("create_account_title")
-            .navigationTitle("create_account_title")
+        VStack(spacing: 16) {
+            TextField("full_name_placeholder", text: $fullName)
+                .autocapitalization(.words)
+                .padding()
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.gray.opacity(0.5))
+                )
+            if let fullNameError = fullNameError {
+                Text(fullNameError)
+                    .foregroundColor(.red)
+                    .font(.caption)
+            }
+
+            TextField("email_placeholder", text: $email)
+                .autocapitalization(.none)
+                .keyboardType(.emailAddress)
+                .padding()
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.gray.opacity(0.5))
+                )
+            if let emailError = emailError {
+                Text(emailError)
+                    .foregroundColor(.red)
+                    .font(.caption)
+            }
+
+            SecureField("password_placeholder", text: $password)
+                .padding()
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.gray.opacity(0.5))
+                )
+            if let passwordError = passwordError {
+                Text(passwordError)
+                    .foregroundColor(.red)
+                    .font(.caption)
+            }
+
+            SecureField("confirm_password_placeholder", text: $confirmPassword)
+                .padding()
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.gray.opacity(0.5))
+                )
+            if let confirmPasswordError = confirmPasswordError {
+                Text(confirmPasswordError)
+                    .foregroundColor(.red)
+                    .font(.caption)
+            }
+
+            Toggle("accept_terms_label", isOn: $acceptTerms)
+            if let termsError = termsError {
+                Text(termsError)
+                    .foregroundColor(.red)
+                    .font(.caption)
+            }
+
+            Toggle("data_consent_label", isOn: $dataConsent)
+            if let dataConsentError = dataConsentError {
+                Text(dataConsentError)
+                    .foregroundColor(.red)
+                    .font(.caption)
+            }
+
+            Button("create_account_button") {
+                validate()
+            }
+            .padding()
+            .frame(maxWidth: .infinity)
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+        .navigationTitle("create_account_title")
+        .alert("account_created_message", isPresented: $showAlert) {
+            Button("OK") {
+                dismiss()
+            }
+        }
+    }
+
+    private func validate() {
+        fullNameError = fullName.isEmpty ? NSLocalizedString("invalid_full_name", comment: "") : nil
+        emailError = isValidEmail(email) ? nil : NSLocalizedString("invalid_email", comment: "")
+        passwordError = password.count >= 6 ? nil : NSLocalizedString("invalid_password", comment: "")
+        confirmPasswordError = (confirmPassword == password) ? nil : NSLocalizedString("passwords_do_not_match", comment: "")
+        termsError = acceptTerms ? nil : NSLocalizedString("must_accept_terms", comment: "")
+        dataConsentError = dataConsent ? nil : NSLocalizedString("must_consent_data", comment: "")
+
+        if fullNameError == nil &&
+            emailError == nil &&
+            passwordError == nil &&
+            confirmPasswordError == nil &&
+            termsError == nil &&
+            dataConsentError == nil {
+            showAlert = true
+        }
+    }
+
+    private func isValidEmail(_ value: String) -> Bool {
+        let pattern = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
+        return NSPredicate(format: "SELF MATCHES %@", pattern).evaluate(with: value)
     }
 }
 

--- a/my-documents/en.lproj/Localizable.strings
+++ b/my-documents/en.lproj/Localizable.strings
@@ -8,3 +8,13 @@
 "create_account_link" = "Create Account";
 "forgot_password_title" = "Forgot Password";
 "create_account_title" = "Create Account";
+"full_name_placeholder" = "Full Name";
+"confirm_password_placeholder" = "Confirm Password";
+"accept_terms_label" = "I accept the terms";
+"data_consent_label" = "Consent to data usage";
+"invalid_full_name" = "Please enter your full name.";
+"passwords_do_not_match" = "Passwords do not match.";
+"must_accept_terms" = "You must accept the terms.";
+"must_consent_data" = "You must consent to data usage.";
+"create_account_button" = "Create Account";
+"account_created_message" = "Account created successfully.";

--- a/my-documents/es.lproj/Localizable.strings
+++ b/my-documents/es.lproj/Localizable.strings
@@ -8,3 +8,13 @@
 "create_account_link" = "Crear cuenta";
 "forgot_password_title" = "Olvidaste tu contraseña";
 "create_account_title" = "Crear cuenta";
+"full_name_placeholder" = "Nombre completo";
+"confirm_password_placeholder" = "Confirmar contraseña";
+"accept_terms_label" = "Acepto los términos";
+"data_consent_label" = "Consentimiento de uso de datos";
+"invalid_full_name" = "Ingrese su nombre completo.";
+"passwords_do_not_match" = "Las contraseñas no coinciden.";
+"must_accept_terms" = "Debe aceptar los términos.";
+"must_consent_data" = "Debe consentir el uso de datos.";
+"create_account_button" = "Crear cuenta";
+"account_created_message" = "La cuenta se ha creado";


### PR DESCRIPTION
## Summary
- add localized strings for account creation fields
- create account view with inputs, toggles, validation, and success alert

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68961c2902b8832cb9494745c990e2c1