### PR TITLE
Implement tabbed main interface with document management

### DIFF
--- a/my-documents/AccountView.swift
+++ b/my-documents/AccountView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct AccountView: View {
+    var body: some View {
+        NavigationStack {
+            Text("Mi cuenta")
+                .navigationTitle("Mi cuenta")
+        }
+    }
+}
+
+#Preview {
+    AccountView()
+}

--- a/my-documents/Document.swift
+++ b/my-documents/Document.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct Document: Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var type: String
+    var description: String
+    var date: Date
+
+    init(id: UUID = UUID(), name: String, type: String, description: String, date: Date = Date()) {
+        self.id = id
+        self.name = name
+        self.type = type
+        self.description = description
+        self.date = date
+    }
+}

--- a/my-documents/DocumentFormView.swift
+++ b/my-documents/DocumentFormView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct DocumentFormView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String
+    @State private var type: String
+    @State private var description: String
+    @State private var nameError: Bool = false
+    @State private var showAlert: Bool = false
+
+    var document: Document?
+    var onSave: (Document) -> Void
+
+    init(document: Document?, onSave: @escaping (Document) -> Void) {
+        self.document = document
+        _name = State(initialValue: document?.name ?? "")
+        _type = State(initialValue: document?.type ?? "")
+        _description = State(initialValue: document?.description ?? "")
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Nombre", text: $name)
+                    if nameError {
+                        Text("El nombre es obligatorio")
+                            .foregroundColor(.red)
+                            .font(.caption)
+                    }
+                    TextField("Tipo", text: $type)
+                    TextField("Descripción", text: $description)
+                }
+            }
+            .navigationTitle(document == nil ? "Nuevo documento" : "Editar documento")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancelar") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Guardar") {
+                        if name.trimmingCharacters(in: .whitespaces).isEmpty {
+                            nameError = true
+                        } else {
+                            nameError = false
+                            let doc = Document(id: document?.id ?? UUID(),
+                                               name: name,
+                                               type: type,
+                                               description: description,
+                                               date: document?.date ?? Date())
+                            onSave(doc)
+                            showAlert = true
+                        }
+                    }
+                }
+            }
+            .alert("Documento guardado", isPresented: $showAlert) {
+                Button("OK") { dismiss() }
+            }
+        }
+    }
+}
+
+#Preview {
+    DocumentFormView(document: nil) { _ in }
+}

--- a/my-documents/DocumentsView.swift
+++ b/my-documents/DocumentsView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct DocumentsView: View {
+    @State private var documents: [Document] = [
+        Document(name: "Contrato", type: "PDF", description: "Contrato de alquiler"),
+        Document(name: "Factura", type: "DOC", description: "Factura enero")
+    ]
+    @State private var showingForm = false
+    @State private var documentToEdit: Document?
+    @State private var documentToDelete: Document?
+    @State private var showDeleteConfirmation = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(documents) { doc in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(doc.name)
+                                .font(.headline)
+                            Text(dateFormatter.string(from: doc.date))
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                        }
+                        Spacer()
+                        Text(doc.type)
+                            .font(.caption)
+                            .padding(4)
+                            .background(Color.gray.opacity(0.2))
+                            .cornerRadius(8)
+                    }
+                    .swipeActions(edge: .trailing) {
+                        Button("Eliminar", role: .destructive) {
+                            documentToDelete = doc
+                            showDeleteConfirmation = true
+                        }
+                        Button("Editar") {
+                            documentToEdit = doc
+                            showingForm = true
+                        }.tint(.blue)
+                    }
+                }
+            }
+            .navigationTitle("Mis documentos")
+            .toolbar {
+                Button {
+                    documentToEdit = nil
+                    showingForm = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+            .confirmationDialog("¿Eliminar documento?", isPresented: $showDeleteConfirmation) {
+                Button("Eliminar", role: .destructive) {
+                    if let doc = documentToDelete, let index = documents.firstIndex(of: doc) {
+                        documents.remove(at: index)
+                    }
+                }
+                Button("Cancelar", role: .cancel) { }
+            }
+            .sheet(isPresented: $showingForm) {
+                DocumentFormView(document: documentToEdit) { newDoc in
+                    if let index = documents.firstIndex(where: { $0.id == newDoc.id }) {
+                        documents[index] = newDoc
+                    } else {
+                        documents.append(newDoc)
+                    }
+                }
+            }
+        }
+    }
+
+    private var dateFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.dateStyle = .short
+        return df
+    }
+}
+
+#Preview {
+    DocumentsView()
+}

--- a/my-documents/LoginView.swift
+++ b/my-documents/LoginView.swift
@@ -13,6 +13,7 @@ struct LoginView: View {
     @State private var emailError: String?
     @State private var passwordError: String?
     @State private var showPassword: Bool = false
+    @State private var showMain: Bool = false
 
     var body: some View {
         NavigationStack {
@@ -83,13 +84,16 @@ struct LoginView: View {
             }
             .padding()
         }
+        .fullScreenCover(isPresented: $showMain) {
+            MainTabView()
+        }
     }
 
     private func validate() {
         emailError = isValidEmail(email) ? nil : NSLocalizedString("invalid_email", comment: "")
         passwordError = password.count >= 6 ? nil : NSLocalizedString("invalid_password", comment: "")
         if emailError == nil && passwordError == nil {
-            // Authentication logic would go here
+            showMain = true
         }
     }
 

--- a/my-documents/MainTabView.swift
+++ b/my-documents/MainTabView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            DocumentsView()
+                .tabItem {
+                    Image(systemName: "doc.text")
+                    Text("Mis documentos")
+                }
+            NotificationsView()
+                .tabItem {
+                    Image(systemName: "bell")
+                    Text("Notificaciones")
+                }
+            SettingsView()
+                .tabItem {
+                    Image(systemName: "gearshape")
+                    Text("Configuración")
+                }
+            AccountView()
+                .tabItem {
+                    Image(systemName: "person")
+                    Text("Mi cuenta")
+                }
+        }
+    }
+}
+
+#Preview {
+    MainTabView()
+}

--- a/my-documents/NotificationsView.swift
+++ b/my-documents/NotificationsView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct NotificationsView: View {
+    @State private var notifications: [String] = [
+        "Documento A actualizado",
+        "Nuevo mensaje",
+        "Recordatorio de pago"
+    ]
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(notifications, id: \.self) { item in
+                    Text(item)
+                }
+                .onDelete { indices in
+                    notifications.remove(atOffsets: indices)
+                }
+            }
+            .navigationTitle("Notificaciones")
+        }
+    }
+}
+
+#Preview {
+    NotificationsView()
+}

--- a/my-documents/SettingsView.swift
+++ b/my-documents/SettingsView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        NavigationStack {
+            Text("Configuración")
+                .navigationTitle("Configuración")
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}


### PR DESCRIPTION
## Summary
- Add main TabView with sections for documents, notifications, settings, and account
- Implement document CRUD with list, form, edit, delete confirmation, and save alert
- Connect login flow to display the tabbed interface on successful validation

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme my-documents -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_6896efad13e4832c8810a408a08a7a28