### PR TITLE
Add attachment gallery to document form

### DIFF
--- a/my-documents/Attachment.swift
+++ b/my-documents/Attachment.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct Attachment: Identifiable, Equatable {
+    let id: UUID
+    var url: URL
+    var isImage: Bool
+
+    init(id: UUID = UUID(), url: URL, isImage: Bool) {
+        self.id = id
+        self.url = url
+        self.isImage = isImage
+    }
+}

--- a/my-documents/Document.swift
+++ b/my-documents/Document.swift
@@ -6,12 +6,14 @@ struct Document: Identifiable, Equatable {
     var type: String
     var description: String
     var date: Date
+    var attachments: [Attachment]
 
-    init(id: UUID = UUID(), name: String, type: String, description: String, date: Date = Date()) {
+    init(id: UUID = UUID(), name: String, type: String, description: String, date: Date = Date(), attachments: [Attachment] = []) {
         self.id = id
         self.name = name
         self.type = type
         self.description = description
         self.date = date
+        self.attachments = attachments
     }
 }


### PR DESCRIPTION
## Summary
- Add `Attachment` model to represent files and images
- Extend `Document` with attachments property
- Display and import files in a grid gallery within `DocumentFormView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6896f4cf9370832ca9a42738f01209b1