### PR TITLE
Add edit option in document detail view

### DIFF
--- a/my-documents/DocumentDetailView.swift
+++ b/my-documents/DocumentDetailView.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 struct DocumentDetailView: View {
-    var document: Document
+    @Binding var document: Document
+    @State private var showingForm = false
 
     var body: some View {
         Form {
@@ -13,6 +14,18 @@ struct DocumentDetailView: View {
             }
         }
         .navigationTitle(document.name)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Editar") {
+                    showingForm = true
+                }
+            }
+        }
+        .sheet(isPresented: $showingForm) {
+            DocumentFormView(document: document) { updatedDoc in
+                document = updatedDoc
+            }
+        }
     }
 
     private var dateFormatter: DateFormatter {
@@ -23,5 +36,5 @@ struct DocumentDetailView: View {
 }
 
 #Preview {
-    DocumentDetailView(document: Document(name: "Contrato", type: "PDF", description: "Contrato de alquiler"))
+    DocumentDetailView(document: .constant(Document(name: "Contrato", type: "PDF", description: "Contrato de alquiler")))
 }

--- a/my-documents/DocumentsView.swift
+++ b/my-documents/DocumentsView.swift
@@ -13,18 +13,18 @@ struct DocumentsView: View {
     var body: some View {
         NavigationStack {
             List {
-                ForEach(documents) { doc in
-                    NavigationLink(destination: DocumentDetailView(document: doc)) {
+                ForEach($documents) { $doc in
+                    NavigationLink(destination: DocumentDetailView(document: $doc)) {
                         HStack {
                             VStack(alignment: .leading) {
-                                Text(doc.name)
+                                Text(doc.wrappedValue.name)
                                     .font(.headline)
-                                Text(dateFormatter.string(from: doc.date))
+                                Text(dateFormatter.string(from: doc.wrappedValue.date))
                                     .font(.caption)
                                     .foregroundColor(.gray)
                             }
                             Spacer()
-                            Text(doc.type)
+                            Text(doc.wrappedValue.type)
                                 .font(.caption)
                                 .padding(4)
                                 .background(Color.gray.opacity(0.2))
@@ -33,11 +33,11 @@ struct DocumentsView: View {
                     }
                     .swipeActions(edge: .trailing) {
                         Button("Eliminar", role: .destructive) {
-                            documentToDelete = doc
+                            documentToDelete = doc.wrappedValue
                             showDeleteConfirmation = true
                         }
                         Button("Editar") {
-                            documentToEdit = doc
+                            documentToEdit = doc.wrappedValue
                             showingForm = true
                         }.tint(.blue)
                     }


### PR DESCRIPTION
## Summary
- allow editing directly from document detail screen
- bind document list items so detail edits are persisted

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896f479ada0832c8ac4af7dc144f3dc