### PR TITLE
Refactor attachment handling in document form

### DIFF
--- a/my-documents/Attachment.swift
+++ b/my-documents/Attachment.swift
@@ -4,10 +4,14 @@ struct Attachment: Identifiable, Equatable {
     let id: UUID
     var url: URL
     var isImage: Bool
+    var label: String
+    var date: Date
 
-    init(id: UUID = UUID(), url: URL, isImage: Bool) {
+    init(id: UUID = UUID(), url: URL, isImage: Bool, label: String? = nil, date: Date = Date()) {
         self.id = id
         self.url = url
         self.isImage = isImage
+        self.label = label ?? url.lastPathComponent
+        self.date = date
     }
 }

--- a/my-documents/AttachmentPreviewView.swift
+++ b/my-documents/AttachmentPreviewView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import UIKit
+
+struct AttachmentPreviewView: View {
+    var url: URL
+    var isImage: Bool
+    var initialLabel: String
+    var onSave: (String) -> Void
+    @State private var label: String
+    @Environment(\.dismiss) private var dismiss
+
+    init(url: URL, isImage: Bool, initialLabel: String, onSave: @escaping (String) -> Void) {
+        self.url = url
+        self.isImage = isImage
+        self.initialLabel = initialLabel
+        self.onSave = onSave
+        _label = State(initialValue: initialLabel)
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack {
+                if isImage, let image = UIImage(contentsOfFile: url.path) {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxHeight: 300)
+                } else {
+                    Image(systemName: iconName(for: url))
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 100, height: 100)
+                }
+                TextField("Nombre", text: $label)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+                Spacer()
+            }
+            .navigationTitle("Vista previa")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancelar") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Guardar") {
+                        onSave(label)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    private func iconName(for url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "pdf":
+            return "doc.richtext"
+        case "txt":
+            return "doc.text"
+        case "zip":
+            return "archivebox"
+        default:
+            return "doc"
+        }
+    }
+}
+
+#Preview {
+    AttachmentPreviewView(url: URL(fileURLWithPath: "/tmp/test.pdf"), isImage: false, initialLabel: "test.pdf") { _ in }
+}


### PR DESCRIPTION
## Summary
- display attachments in a list with name, icon, date and delete action
- add preview with optional label rename before attaching files
- extend Attachment model with label and date

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6897079fa7bc832ca6c84dbd946ffbbb