### PR TITLE
Add local persistence for user and documents

### DIFF
--- a/my-documents/Attachment.swift
+++ b/my-documents/Attachment.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Attachment: Identifiable, Equatable {
+struct Attachment: Identifiable, Equatable, Codable {
     let id: UUID
     var url: URL
     var isImage: Bool

--- a/my-documents/CreateAccountView.swift
+++ b/my-documents/CreateAccountView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CreateAccountView: View {
     @Environment(\.dismiss) private var dismiss
+    @AppStorage("userEmail") private var storedEmail: String = ""
     @State private var fullName: String = ""
     @State private var email: String = ""
     @State private var password: String = ""
@@ -152,6 +153,9 @@ struct CreateAccountView: View {
             confirmPasswordError == nil &&
             termsError == nil &&
             dataConsentError == nil {
+            let user = User(fullName: fullName, email: email, password: password)
+            PersistenceManager.shared.saveUser(user)
+            storedEmail = email
             showAlert = true
         }
     }

--- a/my-documents/Document.swift
+++ b/my-documents/Document.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Document: Identifiable, Equatable {
+struct Document: Identifiable, Equatable, Codable {
     let id: UUID
     var name: String
     var type: String

--- a/my-documents/DocumentFormView.swift
+++ b/my-documents/DocumentFormView.swift
@@ -186,7 +186,8 @@ struct DocumentFormView: View {
                         } else {
                             let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
                             let date = attrs?[.creationDate] as? Date ?? Date()
-                            attachments.append(Attachment(url: url, isImage: selectedFileIsImage, label: label, date: date))
+                            let savedURL = PersistenceManager.shared.saveAttachment(from: url) ?? url
+                            attachments.append(Attachment(url: savedURL, isImage: selectedFileIsImage, label: label, date: date))
                             nextAttachmentNumber += 1
                         }
                     }

--- a/my-documents/DocumentsView.swift
+++ b/my-documents/DocumentsView.swift
@@ -1,10 +1,7 @@
 import SwiftUI
 
 struct DocumentsView: View {
-    @State private var documents: [Document] = [
-        Document(name: "Contrato", type: "PDF", description: "Contrato de alquiler"),
-        Document(name: "Factura", type: "DOC", description: "Factura enero")
-    ]
+    @State private var documents: [Document] = []
     @State private var showingForm = false
     @State private var documentToEdit: Document?
     @State private var documentToDelete: Document?
@@ -71,6 +68,12 @@ struct DocumentsView: View {
                         documents.append(newDoc)
                     }
                 }
+            }
+            .onAppear {
+                documents = PersistenceManager.shared.loadDocuments()
+            }
+            .onChange(of: documents) { newValue in
+                PersistenceManager.shared.saveDocuments(newValue)
             }
         }
     }

--- a/my-documents/LoginView.swift
+++ b/my-documents/LoginView.swift
@@ -94,8 +94,14 @@ struct LoginView: View {
         emailError = isValidEmail(email) ? nil : NSLocalizedString("invalid_email", comment: "")
         passwordError = password.count >= 6 ? nil : NSLocalizedString("invalid_password", comment: "")
         if emailError == nil && passwordError == nil {
-            storedEmail = email
-            isLoggedIn = true
+            if let user = PersistenceManager.shared.loadUser(),
+               user.email == email,
+               user.password == password {
+                storedEmail = email
+                isLoggedIn = true
+            } else {
+                passwordError = NSLocalizedString("invalid_credentials", comment: "")
+            }
         }
     }
 

--- a/my-documents/PersistenceManager.swift
+++ b/my-documents/PersistenceManager.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+class PersistenceManager {
+    static let shared = PersistenceManager()
+    private let userURL: URL
+    private let documentsURL: URL
+    private let attachmentsDirectory: URL
+
+    private init() {
+        let directory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        userURL = directory.appendingPathComponent("user.json")
+        documentsURL = directory.appendingPathComponent("documents.json")
+        attachmentsDirectory = directory.appendingPathComponent("attachments")
+        try? FileManager.default.createDirectory(at: attachmentsDirectory, withIntermediateDirectories: true)
+    }
+
+    // MARK: - User
+    func saveUser(_ user: User) {
+        do {
+            let data = try JSONEncoder().encode(user)
+            try data.write(to: userURL, options: .atomic)
+        } catch {
+            print("Error saving user: \(error)")
+        }
+    }
+
+    func loadUser() -> User? {
+        guard let data = try? Data(contentsOf: userURL) else { return nil }
+        return try? JSONDecoder().decode(User.self, from: data)
+    }
+
+    // MARK: - Documents
+    func saveDocuments(_ documents: [Document]) {
+        do {
+            let data = try JSONEncoder().encode(documents)
+            try data.write(to: documentsURL, options: .atomic)
+        } catch {
+            print("Error saving documents: \(error)")
+        }
+    }
+
+    func loadDocuments() -> [Document] {
+        guard let data = try? Data(contentsOf: documentsURL) else { return [] }
+        return (try? JSONDecoder().decode([Document].self, from: data)) ?? []
+    }
+
+    // MARK: - Attachments
+    func saveAttachment(from url: URL) -> URL? {
+        let destination = attachmentsDirectory.appendingPathComponent(url.lastPathComponent)
+        do {
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.copyItem(at: url, to: destination)
+            return destination
+        } catch {
+            print("Error saving attachment: \(error)")
+            return nil
+        }
+    }
+}
+

--- a/my-documents/User.swift
+++ b/my-documents/User.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct User: Codable {
+    var fullName: String
+    var email: String
+    var password: String
+}
+

--- a/my-documents/en.lproj/Localizable.strings
+++ b/my-documents/en.lproj/Localizable.strings
@@ -31,3 +31,4 @@
 "password_reset_message" = "Your password has been reset successfully.";
 "my_account_title" = "My Account";
 "logout_button" = "Sign Out";
+"invalid_credentials" = "Incorrect email or password.";

--- a/my-documents/es.lproj/Localizable.strings
+++ b/my-documents/es.lproj/Localizable.strings
@@ -31,3 +31,4 @@
 "password_reset_message" = "La contraseña ha sido restablecida correctamente.";
 "my_account_title" = "Mi cuenta";
 "logout_button" = "Cerrar sesión";
+"invalid_credentials" = "Correo o contraseña incorrectos.";


### PR DESCRIPTION
## Summary
- add PersistenceManager to store users, documents, and attachments on disk
- persist user info during account creation and validate credentials on login
- load and save documents automatically and copy attachments to persistent storage

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68972525026c832c948d634b09d212ac