### PR TITLE
Show toast after saving document

### DIFF
--- a/my-documents/DocumentFormView.swift
+++ b/my-documents/DocumentFormView.swift
@@ -8,7 +8,6 @@ struct DocumentFormView: View {
     @State private var type: String
     @State private var description: String
     @State private var nameError: Bool = false
-    @State private var showAlert: Bool = false
     @State private var attachments: [Attachment]
     @State private var showFileImporter: Bool = false
     @State private var showAddOptions: Bool = false
@@ -121,13 +120,10 @@ struct DocumentFormView: View {
                                date: document?.date ?? Date(),
                                attachments: attachments)
                             onSave(doc)
-                            showAlert = true
+                            dismiss()
                         }
                     }
                 }
-            }
-            .alert("Documento guardado", isPresented: $showAlert) {
-                Button("OK") { dismiss() }
             }
             .fileImporter(isPresented: $showFileImporter, allowedContentTypes: [.image, .pdf, .plainText, .data]) { result in
                 switch result {

--- a/my-documents/DocumentsView.swift
+++ b/my-documents/DocumentsView.swift
@@ -7,6 +7,7 @@ struct DocumentsView: View {
     @State private var documentToDelete: Document?
     @State private var showDeleteConfirmation = false
     @State private var searchText: String = ""
+    @State private var showToast: Bool = false
 
     var body: some View {
         NavigationStack {
@@ -67,6 +68,7 @@ struct DocumentsView: View {
                     } else {
                         documents.append(newDoc)
                     }
+                    showToast = true
                 }
             }
             .onAppear {
@@ -76,6 +78,7 @@ struct DocumentsView: View {
                 PersistenceManager.shared.saveDocuments(newValue)
             }
         }
+        .toast(message: "Documento guardado", isPresented: $showToast)
     }
 
     private var dateFormatter: DateFormatter {

--- a/my-documents/Toast.swift
+++ b/my-documents/Toast.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct ToastModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    let message: String
+
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            if isPresented {
+                VStack {
+                    Spacer()
+                    Text(message)
+                        .padding()
+                        .background(Color.black.opacity(0.7))
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                        .padding(.bottom, 16)
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                        withAnimation {
+                            isPresented = false
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+extension View {
+    func toast(message: String, isPresented: Binding<Bool>) -> some View {
+        self.modifier(ToastModifier(isPresented: isPresented, message: message))
+    }
+}


### PR DESCRIPTION
## Summary
- Replace save confirmation alert with automatic dismissal
- Display toast message on document list when save completes
- Add reusable toast view modifier for notifications

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68973e80af5c832cb0b6b89f98a48cf7