### PR TITLE
Enable pinch-to-zoom for image previews

### DIFF
--- a/my-documents/AttachmentPreviewView.swift
+++ b/my-documents/AttachmentPreviewView.swift
@@ -24,9 +24,7 @@ struct AttachmentPreviewView: View {
             VStack {
                 if isImage {
                     if let uiImage = image ?? UIImage(contentsOfFile: url.path) {
-                        Image(uiImage: uiImage)
-                            .resizable()
-                            .scaledToFit()
+                        ZoomableImageView(image: uiImage)
                             .frame(maxHeight: 300)
                     } else {
                         Image(systemName: "photo")
@@ -45,7 +43,6 @@ struct AttachmentPreviewView: View {
                     .padding()
                 Spacer()
             }
-            .navigationTitle("Vista previa")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancelar") { dismiss() }

--- a/my-documents/ZoomableImageView.swift
+++ b/my-documents/ZoomableImageView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import UIKit
+
+struct ZoomableImageView: UIViewRepresentable {
+    let image: UIImage
+
+    func makeUIView(context: Context) -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.delegate = context.coordinator
+        scrollView.minimumZoomScale = 1.0
+        scrollView.maximumZoomScale = 4.0
+        scrollView.zoomScale = 1.0
+
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleAspectFit
+        imageView.frame = scrollView.bounds
+        imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        scrollView.addSubview(imageView)
+
+        context.coordinator.imageView = imageView
+        return scrollView
+    }
+
+    func updateUIView(_ uiView: UIScrollView, context: Context) {
+        context.coordinator.imageView?.image = image
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    class Coordinator: NSObject, UIScrollViewDelegate {
+        var imageView: UIImageView?
+
+        func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+            imageView
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow pinching to zoom image attachments with a new `ZoomableImageView`
- remove "Vista previa" title from attachment preview

## Testing
- `xcodebuild test -scheme my-documents` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689740be5550832cafbc4c4e0ef97a97