### PR TITLE
feat: inline editing in document detail

### DIFF
--- a/my-documents/AttachmentPreviewView.swift
+++ b/my-documents/AttachmentPreviewView.swift
@@ -6,15 +6,17 @@ struct AttachmentPreviewView: View {
     var isImage: Bool
     var initialLabel: String
     var image: UIImage?
+    var allowEditing: Bool
     var onSave: (String) -> Void
     @State private var label: String
     @Environment(\.dismiss) private var dismiss
 
-    init(url: URL, isImage: Bool, initialLabel: String, image: UIImage? = nil, onSave: @escaping (String) -> Void) {
+    init(url: URL, isImage: Bool, initialLabel: String, image: UIImage? = nil, allowEditing: Bool = true, onSave: @escaping (String) -> Void = { _ in }) {
         self.url = url
         self.isImage = isImage
         self.initialLabel = initialLabel
         self.image = image
+        self.allowEditing = allowEditing
         self.onSave = onSave
         _label = State(initialValue: initialLabel)
     }
@@ -38,19 +40,26 @@ struct AttachmentPreviewView: View {
                         .scaledToFit()
                         .frame(width: 100, height: 100)
                 }
-                TextField("Nombre", text: $label)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .padding()
+                if allowEditing {
+                    TextField("Nombre", text: $label)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .padding()
+                } else {
+                    Text(label)
+                        .padding()
+                }
                 Spacer()
             }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancelar") { dismiss() }
+                    Button(allowEditing ? "Cancelar" : "Cerrar") { dismiss() }
                 }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Guardar") {
-                        onSave(label)
-                        dismiss()
+                if allowEditing {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Guardar") {
+                            onSave(label)
+                            dismiss()
+                        }
                     }
                 }
             }

--- a/my-documents/DocumentDetailView.swift
+++ b/my-documents/DocumentDetailView.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 struct DocumentDetailView: View {
     @Binding var document: Document
-    @State private var showingForm = false
+    @State private var isEditing = false
     @State private var selectedAttachment: Attachment?
     @State private var showFileImporter = false
     @State private var showAddOptions = false
@@ -29,9 +29,16 @@ struct DocumentDetailView: View {
     var body: some View {
         Form {
             Section(header: Text("Información")) {
-                Text("Nombre: \(document.name)")
-                Text("Tipo: \(document.type)")
-                Text("Descripción: \(document.description)")
+                TextField("Nombre", text: $document.name)
+                    .disabled(!isEditing)
+                TextField("Tipo", text: $document.type)
+                    .disabled(!isEditing)
+                VStack(alignment: .leading) {
+                    Text("Descripción")
+                    TextEditor(text: $document.description)
+                        .frame(minHeight: 100)
+                        .disabled(!isEditing)
+                }
                 Text("Fecha: \(dateFormatter.string(from: document.date))")
             }
 
@@ -52,23 +59,19 @@ struct DocumentDetailView: View {
                 } label: {
                     Label("Agregar", systemImage: "paperclip")
                 }
+                .disabled(!isEditing)
             }
         }
         .navigationTitle(document.name)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button("Editar") {
-                    showingForm = true
+                Button(isEditing ? "Guardar" : "Editar") {
+                    isEditing.toggle()
                 }
             }
         }
-        .sheet(isPresented: $showingForm) {
-            DocumentFormView(document: document) { updatedDoc in
-                document = updatedDoc
-            }
-        }
         .sheet(item: $selectedAttachment) { attachment in
-            AttachmentPreviewView(url: attachment.url, isImage: attachment.isImage, initialLabel: attachment.label) { label in
+            AttachmentPreviewView(url: attachment.url, isImage: attachment.isImage, initialLabel: attachment.label, allowEditing: isEditing) { label in
                 if let index = document.attachments.firstIndex(where: { $0.id == attachment.id }) {
                     document.attachments[index].label = label
                 }

--- a/my-documents/DocumentsView.swift
+++ b/my-documents/DocumentsView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct DocumentsView: View {
     @State private var documents: [Document] = []
     @State private var showingForm = false
-    @State private var documentToEdit: Document?
     @State private var documentToDelete: Document?
     @State private var showDeleteConfirmation = false
     @State private var searchText: String = ""
@@ -36,10 +35,6 @@ struct DocumentsView: View {
                             documentToDelete = doc.wrappedValue
                             showDeleteConfirmation = true
                         }
-                        Button("Editar") {
-                            documentToEdit = doc.wrappedValue
-                            showingForm = true
-                        }.tint(.blue)
                     }
                 }
             }
@@ -47,7 +42,6 @@ struct DocumentsView: View {
             .navigationTitle("Mis documentos")
             .toolbar {
                 Button {
-                    documentToEdit = nil
                     showingForm = true
                 } label: {
                     Image(systemName: "plus")
@@ -62,12 +56,8 @@ struct DocumentsView: View {
                 Button("Cancelar", role: .cancel) { }
             }
             .sheet(isPresented: $showingForm) {
-                DocumentFormView(document: documentToEdit) { newDoc in
-                    if let index = documents.firstIndex(where: { $0.id == newDoc.id }) {
-                        documents[index] = newDoc
-                    } else {
-                        documents.append(newDoc)
-                    }
+                DocumentFormView(document: nil) { newDoc in
+                    documents.append(newDoc)
                     showToast = true
                 }
             }


### PR DESCRIPTION
## Summary
- allow editing document details inline with read-only fields that toggle on "Editar"
- support read-only previews for attachments
- remove separate edit screen; use form only for creating documents

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689a055fc0f4832cb3487d792d4afc09