### PR TITLE
Use navigation push for new documents

### DIFF
--- a/my-documents/DocumentFormView.swift
+++ b/my-documents/DocumentFormView.swift
@@ -38,8 +38,7 @@ struct DocumentFormView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            Form {
+        Form {
                 Section {
                     TextField("Nombre", text: $name)
                     if nameError {
@@ -94,39 +93,36 @@ struct DocumentFormView: View {
                     }
                 }
             }
-            .alert(item: $attachmentToDelete) { file in
-                Alert(
-                    title: Text("Eliminar archivo"),
-                    message: Text("¿Deseas eliminar \(file.label)?"),
-                    primaryButton: .destructive(Text("Eliminar")) {
-                        attachments.removeAll { $0.id == file.id }
-                    },
-                    secondaryButton: .cancel()
-                )
-            }
-            .navigationTitle(document == nil ? "Nuevo documento" : "Editar documento")
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancelar") { dismiss() }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Guardar") {
-                        if name.trimmingCharacters(in: .whitespaces).isEmpty {
-                            nameError = true
-                        } else {
-                            nameError = false
-                            let doc = Document(id: document?.id ?? UUID(),
-                                name: name,
-                               type: type,
-                               description: description,
-                               date: document?.date ?? Date(),
-                               attachments: attachments)
-                            onSave(doc)
-                            dismiss()
-                        }
+        .alert(item: $attachmentToDelete) { file in
+            Alert(
+                title: Text("Eliminar archivo"),
+                message: Text("¿Deseas eliminar \(file.label)?"),
+                primaryButton: .destructive(Text("Eliminar")) {
+                    attachments.removeAll { $0.id == file.id }
+                },
+                secondaryButton: .cancel()
+            )
+        }
+        .navigationTitle(document == nil ? "Nuevo documento" : "Editar documento")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Guardar") {
+                    if name.trimmingCharacters(in: .whitespaces).isEmpty {
+                        nameError = true
+                    } else {
+                        nameError = false
+                        let doc = Document(id: document?.id ?? UUID(),
+                            name: name,
+                           type: type,
+                           description: description,
+                           date: document?.date ?? Date(),
+                           attachments: attachments)
+                        onSave(doc)
+                        dismiss()
                     }
                 }
             }
+        }
             .fileImporter(isPresented: $showFileImporter, allowedContentTypes: [.image, .pdf, .plainText, .data]) { result in
                 switch result {
                 case .success(let url):
@@ -183,22 +179,21 @@ struct DocumentFormView: View {
                     }
                 }
             }
-            .sheet(isPresented: $showAttachmentPreview, onDismiss: {
-                selectedImage = nil
-                selectedFileURL = nil
-                editingAttachmentID = nil
-            }) {
-                if let url = selectedFileURL {
-                    AttachmentPreviewView(url: url, isImage: selectedFileIsImage, initialLabel: selectedFileLabel, image: selectedImage) { label in
-                        if let editingID = editingAttachmentID, let index = attachments.firstIndex(where: { $0.id == editingID }) {
-                            attachments[index].label = label
-                        } else {
-                            let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
-                            let date = attrs?[.creationDate] as? Date ?? Date()
-                            let savedURL = PersistenceManager.shared.saveAttachment(from: url) ?? url
-                            attachments.append(Attachment(url: savedURL, isImage: selectedFileIsImage, label: label, date: date))
-                            nextAttachmentNumber += 1
-                        }
+        .sheet(isPresented: $showAttachmentPreview, onDismiss: {
+            selectedImage = nil
+            selectedFileURL = nil
+            editingAttachmentID = nil
+        }) {
+            if let url = selectedFileURL {
+                AttachmentPreviewView(url: url, isImage: selectedFileIsImage, initialLabel: selectedFileLabel, image: selectedImage) { label in
+                    if let editingID = editingAttachmentID, let index = attachments.firstIndex(where: { $0.id == editingID }) {
+                        attachments[index].label = label
+                    } else {
+                        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+                        let date = attrs?[.creationDate] as? Date ?? Date()
+                        let savedURL = PersistenceManager.shared.saveAttachment(from: url) ?? url
+                        attachments.append(Attachment(url: savedURL, isImage: selectedFileIsImage, label: label, date: date))
+                        nextAttachmentNumber += 1
                     }
                 }
             }

--- a/my-documents/DocumentsView.swift
+++ b/my-documents/DocumentsView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct DocumentsView: View {
     @State private var documents: [Document] = []
-    @State private var showingForm = false
     @State private var documentToDelete: Document?
     @State private var showDeleteConfirmation = false
     @State private var searchText: String = ""
@@ -41,8 +40,11 @@ struct DocumentsView: View {
             .searchable(text: $searchText)
             .navigationTitle("Mis documentos")
             .toolbar {
-                Button {
-                    showingForm = true
+                NavigationLink {
+                    DocumentFormView(document: nil) { newDoc in
+                        documents.append(newDoc)
+                        showToast = true
+                    }
                 } label: {
                     Image(systemName: "plus")
                 }
@@ -54,12 +56,6 @@ struct DocumentsView: View {
                     }
                 }
                 Button("Cancelar", role: .cancel) { }
-            }
-            .sheet(isPresented: $showingForm) {
-                DocumentFormView(document: nil) { newDoc in
-                    documents.append(newDoc)
-                    showToast = true
-                }
             }
             .onAppear {
                 documents = PersistenceManager.shared.loadDocuments()


### PR DESCRIPTION
## Summary
- open "Agregar" document form via navigation push instead of a sheet
- rely on navigation stack in the document form and remove cancel button

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b0283e984832c9cfb7c9bd6f45dcc