### PR TITLE
Use navigation for new documents and fix attachment preview

### DIFF
--- a/my-documents/DocumentsView.swift
+++ b/my-documents/DocumentsView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct DocumentsView: View {
     @State private var documents: [Document] = []
-    @State private var showingForm = false
     @State private var documentToDelete: Document?
     @State private var showDeleteConfirmation = false
     @State private var searchText: String = ""
@@ -41,8 +40,11 @@ struct DocumentsView: View {
             .searchable(text: $searchText)
             .navigationTitle("Mis documentos")
             .toolbar {
-                Button {
-                    showingForm = true
+                NavigationLink {
+                    DocumentFormView(document: nil) { newDoc in
+                        documents.append(newDoc)
+                        showToast = true
+                    }
                 } label: {
                     Image(systemName: "plus")
                 }
@@ -54,12 +56,6 @@ struct DocumentsView: View {
                     }
                 }
                 Button("Cancelar", role: .cancel) { }
-            }
-            .sheet(isPresented: $showingForm) {
-                DocumentFormView(document: nil) { newDoc in
-                    documents.append(newDoc)
-                    showToast = true
-                }
             }
             .onAppear {
                 documents = PersistenceManager.shared.loadDocuments()


### PR DESCRIPTION
## Summary
- push the document creation form onto the navigation stack
- ensure attachment previews work for newly created documents

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689b15abb82c832ca840c6d1e60ef9ff